### PR TITLE
Refactor autotests for categories

### DIFF
--- a/main-service/src/test/java/ru/practicum/ewm/category/CategoryAdminControllerIT.java
+++ b/main-service/src/test/java/ru/practicum/ewm/category/CategoryAdminControllerIT.java
@@ -15,11 +15,11 @@ import ru.practicum.ewm.common.ClockConfig;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -67,7 +67,7 @@ class CategoryAdminControllerIT {
     void whenPostAtBasePath_ThenInvokeAddMethodAndProcessResponse() throws Exception {
         final String requestBody = loadJson("add_request.json", getClass());
         final String responseBody = loadJson("add_response.json", getClass());
-        when(mockMapper.mapToCategory(makeTestCategoryCreateDto())).thenReturn(makeTestCategory(NO_ID));
+        when(mockMapper.mapToCategory(any(CategoryCreateDto.class))).thenReturn(makeTestCategory(NO_ID));
         when(mockService.add(any())).thenReturn(makeTestCategory());
         when(mockMapper.mapToDto(any(Category.class))).thenReturn(makeTestCategoryDto());
 
@@ -82,8 +82,8 @@ class CategoryAdminControllerIT {
                         content().json(responseBody, true));
 
         inOrder.verify(mockMapper).mapToCategory(makeTestCategoryCreateDto());
-        inOrder.verify(mockService).add(argThat(samePropertyValuesAs(makeTestCategory(NO_ID))));
-        inOrder.verify(mockMapper).mapToDto(argThat(samePropertyValuesAs(makeTestCategory())));
+        inOrder.verify(mockService).add(refEq(makeTestCategory(NO_ID)));
+        inOrder.verify(mockMapper).mapToDto(refEq(makeTestCategory()));
     }
 
     @Test
@@ -106,8 +106,7 @@ class CategoryAdminControllerIT {
     void whenPatchAtBasePathWithId_ThenInvokeUpdateMethodAndProcessResponse() throws Exception {
         final String requestBody = loadJson("update_request.json", getClass());
         final String responseBody = loadJson("update_response.json", getClass());
-        when(mockMapper.mapToCategoryPatch(CATEGORY_ID, makeTestCategoryUpdateDto()))
-                .thenReturn(makeTestCategoryPatch());
+        when(mockMapper.mapToCategoryPatch(anyLong(), any())).thenReturn(makeTestCategoryPatch());
         when(mockService.update(any())).thenReturn(makeTestCategory());
         when(mockMapper.mapToDto(any(Category.class))).thenReturn(makeTestCategoryDto());
 
@@ -123,7 +122,7 @@ class CategoryAdminControllerIT {
 
         inOrder.verify(mockMapper).mapToCategoryPatch(CATEGORY_ID, makeTestCategoryUpdateDto());
         inOrder.verify(mockService).update(makeTestCategoryPatch());
-        inOrder.verify(mockMapper).mapToDto(argThat(samePropertyValuesAs(makeTestCategory())));
+        inOrder.verify(mockMapper).mapToDto(refEq(makeTestCategory()));
     }
 
     @Test

--- a/main-service/src/test/java/ru/practicum/ewm/category/CategoryAdminControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/ewm/category/CategoryAdminControllerTest.java
@@ -10,11 +10,11 @@ import ru.practicum.ewm.common.LogListener;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static ru.practicum.ewm.category.TestModels.CATEGORY_ID;
 import static ru.practicum.ewm.category.TestModels.NO_ID;
 import static ru.practicum.ewm.category.TestModels.makeTestCategory;
@@ -57,15 +57,15 @@ class CategoryAdminControllerTest extends AbstractControllerTest {
     @Test
     void whenAdd_ThenMapCategoryCreateDtoToCategoryAndPassToServiceAndMapServiceResponseToDtoAndReturnItAndLog()
             throws Exception {
-        when(mockMapper.mapToCategory(makeTestCategoryCreateDto())).thenReturn(makeTestCategory(NO_ID));
+        when(mockMapper.mapToCategory(any(CategoryCreateDto.class))).thenReturn(makeTestCategory(NO_ID));
         when(mockService.add(any())).thenReturn(makeTestCategory());
         when(mockMapper.mapToDto(any(Category.class))).thenReturn(makeTestCategoryDto());
 
         final CategoryDto categoryDto = controller.add(makeTestCategoryCreateDto(), mockHttpRequest);
 
         inOrder.verify(mockMapper).mapToCategory(makeTestCategoryCreateDto());
-        inOrder.verify(mockService).add(argThat(samePropertyValuesAs(makeTestCategory(NO_ID))));
-        inOrder.verify(mockMapper).mapToDto(argThat(samePropertyValuesAs(makeTestCategory())));
+        inOrder.verify(mockService).add(refEq(makeTestCategory(NO_ID)));
+        inOrder.verify(mockMapper).mapToDto(refEq(makeTestCategory()));
         assertThat(categoryDto, equalTo(makeTestCategoryDto()));
         assertLogs(logListener.getEvents(), "add.json", getClass());
     }
@@ -73,8 +73,7 @@ class CategoryAdminControllerTest extends AbstractControllerTest {
     @Test
     void whenUpdate_ThenMapCategoryUpdateDtoToPatchAndPassToServiceAndMapServiceResponseToDtoAndReturnAndLog()
             throws Exception {
-        when(mockMapper.mapToCategoryPatch(CATEGORY_ID, makeTestCategoryUpdateDto()))
-                .thenReturn(makeTestCategoryPatch());
+        when(mockMapper.mapToCategoryPatch(anyLong(), any())).thenReturn(makeTestCategoryPatch());
         when(mockService.update(any())).thenReturn(makeTestCategory());
         when(mockMapper.mapToDto(any(Category.class))).thenReturn(makeTestCategoryDto());
 
@@ -82,7 +81,7 @@ class CategoryAdminControllerTest extends AbstractControllerTest {
 
         inOrder.verify(mockMapper).mapToCategoryPatch(CATEGORY_ID, makeTestCategoryUpdateDto());
         inOrder.verify(mockService).update(makeTestCategoryPatch());
-        inOrder.verify(mockMapper).mapToDto(argThat(samePropertyValuesAs(makeTestCategory())));
+        inOrder.verify(mockMapper).mapToDto(refEq(makeTestCategory()));
         assertThat(categoryDto, equalTo(makeTestCategoryDto()));
         assertLogs(logListener.getEvents(), "update.json", getClass());
     }

--- a/main-service/src/test/java/ru/practicum/ewm/category/CategoryControllerIT.java
+++ b/main-service/src/test/java/ru/practicum/ewm/category/CategoryControllerIT.java
@@ -15,11 +15,11 @@ import ru.practicum.ewm.common.ClockConfig;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -31,6 +31,7 @@ import static ru.practicum.ewm.category.TestModels.DEFAULT_WINDOW_SIZE;
 import static ru.practicum.ewm.category.TestModels.makeTestCategory;
 import static ru.practicum.ewm.category.TestModels.makeTestCategoryDto;
 import static ru.practicum.ewm.common.CommonUtils.loadJson;
+import static ru.practicum.ewm.common.CommonUtils.refContains;
 
 @WebMvcTest(controllers = CategoryController.class)
 @ContextConfiguration(classes = ClockConfig.class)
@@ -69,7 +70,7 @@ class CategoryControllerIT {
     @Test
     void whenGetAtBasePath_ThenInvokeGetAllMethodAndProcessResponse() throws Exception {
         final String responseBody = loadJson("get_list.json", getClass());
-        when(mockService.getAllInWindow(WINDOW_SIZE, WINDOW_INDEX)).thenReturn(List.of(makeTestCategory()));
+        when(mockService.getAllInWindow(anyInt(), anyInt())).thenReturn(List.of(makeTestCategory()));
         when(mockMapper.mapToDto(anyList())).thenReturn(List.of(makeTestCategoryDto()));
 
         mvc.perform(get(BASE_PATH)
@@ -83,15 +84,13 @@ class CategoryControllerIT {
                         content().json(responseBody, true));
 
         inOrder.verify(mockService).getAllInWindow(WINDOW_SIZE, WINDOW_INDEX);
-        inOrder.verify(mockMapper).mapToDto(argThat((List<Category> categories) ->
-                contains(samePropertyValuesAs(makeTestCategory())).matches(categories)));
+        inOrder.verify(mockMapper).mapToDto(refContains(makeTestCategory()));
     }
 
     @Test
     void whenGetAtBasePathWithoutParams_ThenInvokeGetAllMethodWithDefaultParams() throws Exception {
         final String responseBody = loadJson("get_list_with_default_params.json", getClass());
-        when(mockService.getAllInWindow(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_INDEX))
-                .thenReturn(List.of(makeTestCategory()));
+        when(mockService.getAllInWindow(anyInt(), anyInt())).thenReturn(List.of(makeTestCategory()));
         when(mockMapper.mapToDto(anyList())).thenReturn(List.of(makeTestCategoryDto()));
 
         mvc.perform(get(BASE_PATH)
@@ -103,8 +102,7 @@ class CategoryControllerIT {
                         content().json(responseBody, true));
 
         inOrder.verify(mockService).getAllInWindow(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_INDEX);
-        inOrder.verify(mockMapper).mapToDto(argThat((List<Category> categories) ->
-                contains(samePropertyValuesAs(makeTestCategory())).matches(categories)));
+        inOrder.verify(mockMapper).mapToDto(refContains(makeTestCategory()));
     }
 
     @Test
@@ -125,7 +123,7 @@ class CategoryControllerIT {
     @Test
     void whenGetAtBasePathWithId_ThenInvokeGetMethodAndProcessResponse() throws Exception {
         final String responseBody = loadJson("get_single.json", getClass());
-        when(mockService.getById(CATEGORY_ID)).thenReturn(makeTestCategory());
+        when(mockService.getById(anyLong())).thenReturn(makeTestCategory());
         when(mockMapper.mapToDto(any(Category.class))).thenReturn(makeTestCategoryDto());
 
         mvc.perform(get(BASE_PATH + "/" + CATEGORY_ID)
@@ -137,7 +135,6 @@ class CategoryControllerIT {
                         content().json(responseBody, true));
 
         inOrder.verify(mockService).getById(CATEGORY_ID);
-        inOrder.verify(mockMapper).mapToDto(argThat((Category category) ->
-                samePropertyValuesAs(makeTestCategory()).matches(category)));
+        inOrder.verify(mockMapper).mapToDto(refEq(makeTestCategory()));
     }
 }

--- a/main-service/src/test/java/ru/practicum/ewm/category/CategoryControllerTest.java
+++ b/main-service/src/test/java/ru/practicum/ewm/category/CategoryControllerTest.java
@@ -14,15 +14,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.when;
 import static ru.practicum.ewm.category.TestModels.CATEGORY_ID;
 import static ru.practicum.ewm.category.TestModels.makeTestCategory;
 import static ru.practicum.ewm.category.TestModels.makeTestCategoryDto;
 import static ru.practicum.ewm.common.CommonUtils.assertLogs;
+import static ru.practicum.ewm.common.CommonUtils.refContains;
 
 class CategoryControllerTest extends AbstractControllerTest {
 
@@ -61,14 +63,13 @@ class CategoryControllerTest extends AbstractControllerTest {
     @Test
     void whenGetAllCategories_ThenPassWindowParamsToServiceAndMapServiceResponseToDtosAndReturnItAndLog()
             throws Exception {
-        when(mockService.getAllInWindow(WINDOW_SIZE, WINDOW_INDEX)).thenReturn(List.of(makeTestCategory()));
+        when(mockService.getAllInWindow(anyInt(), anyInt())).thenReturn(List.of(makeTestCategory()));
         when(mockMapper.mapToDto(anyList())).thenReturn(List.of(makeTestCategoryDto()));
 
         final List<CategoryDto> categoryDtos = controller.getAll(FROM, SIZE, mockHttpRequest);
 
         inOrder.verify(mockService).getAllInWindow(WINDOW_SIZE, WINDOW_INDEX);
-        inOrder.verify(mockMapper).mapToDto(argThat((List<Category> categories) ->
-                contains(samePropertyValuesAs(makeTestCategory())).matches(categories)));
+        inOrder.verify(mockMapper).mapToDto(refContains(makeTestCategory()));
         assertThat(categoryDtos, contains(makeTestCategoryDto()));
         assertLogs(logListener.getEvents(), "get_list.json", getClass());
     }
@@ -76,7 +77,7 @@ class CategoryControllerTest extends AbstractControllerTest {
     @Test
     void whenGetAllCategoriesAndListIsEmpty_ThenPassWindowParamsToServiceAndMapServiceResponseToDtosAndReturnItAndLog()
             throws Exception {
-        when(mockService.getAllInWindow(WINDOW_SIZE, WINDOW_INDEX)).thenReturn(List.of());
+        when(mockService.getAllInWindow(anyInt(), anyInt())).thenReturn(List.of());
         when(mockMapper.mapToDto(anyList())).thenReturn(List.of());
 
         final List<CategoryDto> categoryDtos = controller.getAll(FROM, SIZE, mockHttpRequest);
@@ -89,14 +90,13 @@ class CategoryControllerTest extends AbstractControllerTest {
 
     @Test
     void whenGetCategoryById_ThenPassIdToServiceAndMapServiceResponseToDtoAndReturnItAndLog() throws Exception {
-        when(mockService.getById(CATEGORY_ID)).thenReturn(makeTestCategory());
+        when(mockService.getById(anyLong())).thenReturn(makeTestCategory());
         when(mockMapper.mapToDto(any(Category.class))).thenReturn(makeTestCategoryDto());
 
         final CategoryDto categoryDto = controller.get(CATEGORY_ID, mockHttpRequest);
 
         inOrder.verify(mockService).getById(CATEGORY_ID);
-        inOrder.verify(mockMapper).mapToDto(argThat((Category category) ->
-                samePropertyValuesAs(makeTestCategory()).matches(category)));
+        inOrder.verify(mockMapper).mapToDto(refEq(makeTestCategory()));
         assertThat(categoryDto, equalTo(makeTestCategoryDto()));
         assertLogs(logListener.getEvents(), "get_single.json", getClass());
     }

--- a/main-service/src/test/java/ru/practicum/ewm/category/CategoryServiceImplTest.java
+++ b/main-service/src/test/java/ru/practicum/ewm/category/CategoryServiceImplTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import ru.practicum.ewm.common.LogListener;
 import ru.practicum.ewm.exception.NotFoundException;
 
@@ -21,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
@@ -76,7 +78,7 @@ class CategoryServiceImplTest {
 
     @Test
     void whenGetExistingCategoryById_ThenRetrieveCategoryFromRepositoryAndReturnIt() {
-        when(mockRepository.findById(CATEGORY_ID)).thenReturn(Optional.of(makeTestCategory()));
+        when(mockRepository.findById(anyLong())).thenReturn(Optional.of(makeTestCategory()));
 
         final Category category = service.getById(CATEGORY_ID);
 
@@ -86,7 +88,7 @@ class CategoryServiceImplTest {
 
     @Test
     void whenGetNotExistingCategoryById_ThenLookForCategoryInRepositoryAndThrowException() {
-        when(mockRepository.findById(CATEGORY_ID)).thenReturn(Optional.empty());
+        when(mockRepository.findById(anyLong())).thenReturn(Optional.empty());
 
         final NotFoundException exception = assertThrows(NotFoundException.class, () -> service.getById(CATEGORY_ID));
 
@@ -97,7 +99,7 @@ class CategoryServiceImplTest {
 
     @Test
     void whenGetSliceOfCategories_ThenRetrieveSliceFromRepositoryAndReturnIt() {
-        when(mockRepository.findAll(DEFAULT_PAGE)).thenReturn(new PageImpl<>(List.of(makeTestCategory())));
+        when(mockRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(makeTestCategory())));
 
         final List<Category> categories = service.getAllInWindow(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_INDEX);
 
@@ -107,7 +109,7 @@ class CategoryServiceImplTest {
 
     @Test
     void whenGetSliceOfCategoriesAndItIsEmpty_ThenRetrieveSliceFromRepositoryAndReturnEmptyList() {
-        when(mockRepository.findAll(DEFAULT_PAGE)).thenReturn(new PageImpl<>(List.of()));
+        when(mockRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of()));
 
         final List<Category> categories = service.getAllInWindow(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_INDEX);
 
@@ -118,7 +120,7 @@ class CategoryServiceImplTest {
     @Test
     void whenUpdateCategory_ThenGetItFromRepositoryAndPassUpdatedToRepositoryAndReturnRepositoryResponseAndLog()
             throws Exception {
-        when(mockRepository.findById(CATEGORY_ID)).thenReturn(Optional.of(makeTestCategory(NO_NAME)));
+        when(mockRepository.findById(anyLong())).thenReturn(Optional.of(makeTestCategory(NO_NAME)));
         when(mockRepository.save(any())).thenReturn(makeTestCategory());
 
         final Category category = service.update(makeTestCategoryPatch());
@@ -132,7 +134,7 @@ class CategoryServiceImplTest {
     @Test
     void whenUpdateCategoryAndNothingToPatch_ThenGetCategoryFromRepositoryAndPassBackAndReturnRepositoryResponseAndLog()
             throws Exception {
-        when(mockRepository.findById(CATEGORY_ID)).thenReturn(Optional.of(makeTestCategory()));
+        when(mockRepository.findById(anyLong())).thenReturn(Optional.of(makeTestCategory()));
         when(mockRepository.save(any())).thenReturn(makeTestCategory());
 
         final Category category = service.update(makeTestCategoryPatch(NO_NAME));
@@ -145,7 +147,7 @@ class CategoryServiceImplTest {
 
     @Test
     void whenUpdateNotExistingCategory_ThenLookForItInRepositoryAndThrowException() {
-        when(mockRepository.findById(CATEGORY_ID)).thenReturn(Optional.empty());
+        when(mockRepository.findById(anyLong())).thenReturn(Optional.empty());
 
         final NotFoundException exception = assertThrows(NotFoundException.class,
                 () -> service.update(makeTestCategoryPatch()));
@@ -157,7 +159,7 @@ class CategoryServiceImplTest {
 
     @Test
     void whenRemoveExistingCategoryById_ThenDeleteItInRepositoryAndLog() throws Exception {
-        when(mockRepository.delete(CATEGORY_ID)).thenReturn(1);
+        when(mockRepository.delete(anyLong())).thenReturn(1);
 
         service.removeById(CATEGORY_ID);
 
@@ -167,7 +169,7 @@ class CategoryServiceImplTest {
 
     @Test
     void whenRemoveNotExistingCategoryById_ThenTryDeleteItInRepositoryAndThrowException() {
-        when(mockRepository.delete(CATEGORY_ID)).thenReturn(0);
+        when(mockRepository.delete(anyLong())).thenReturn(0);
 
         final NotFoundException exception = assertThrows(NotFoundException.class,
                 () -> service.removeById(CATEGORY_ID));

--- a/main-service/src/test/java/ru/practicum/ewm/common/CommonUtils.java
+++ b/main-service/src/test/java/ru/practicum/ewm/common/CommonUtils.java
@@ -6,6 +6,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import org.json.JSONException;
+import org.mockito.ArgumentMatchers;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.core.io.ClassPathResource;
 
@@ -14,6 +15,9 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 
 public final class CommonUtils {
 
@@ -46,5 +50,9 @@ public final class CommonUtils {
         final String expected = loadJson(filename, clazz);
         final String actual = mapper.writeValueAsString(events);
         JSONAssert.assertEquals(expected, actual, false);
+    }
+
+    public static <T> List<T> refContains(final T element) {
+        return ArgumentMatchers.argThat(argument -> contains(samePropertyValuesAs(element)).matches(argument));
     }
 }


### PR DESCRIPTION
- Replace Hamcrest 'samePropertyValuesAs' matcher with Mockito 'refEq' matcher
- Add a custom Mockito matcher to implement checks similar to 'refEq' for lists
- Move to most general Mockito matchers (i.e. any(), anyList(), etc.) in stubs